### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to PiTrackerCommons will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [v0.0.3] - 2025-08-19
+
+### Added
+
+- [DeviceOS](devicedetect/src/main/java/com/ragibn5/devicedetect/DeviceOS.kt)
+  An enum type representing the operating system of the device (limited support, see README).
+
+- ## [v0.0.1] - 2025-08-15
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ Available info (as of now):
   An enum type representing the brand of the device.
 - [DeviceManufacturer](devicedetect/src/main/java/com/ragibn5/devicedetect/DeviceManufacturer.kt)
   An enum type representing the manufacturer of the device.
+- [DeviceOS](devicedetect/src/main/java/com/ragibn5/devicedetect/DeviceOS.kt)
+  An enum type representing the operating system of the device.
+
+Note, The OS detection is verified for only Xiaomi, Transsion, and Nothing devices as of now.
+We will expand the library to support more operating systems with upcoming releases.
 
 ## Building a New Local Release
 
@@ -71,10 +76,38 @@ files.
 
 ## Using in Other Projects
 
-Add this to your build.gradle:
+If you are managing the dependency repositories with settings.gradle (newer projects):
+Add `maven { url 'https://jitpack.io' }` at the end of `dependencyResolutionManagement.repositories`
+block:
 
 ```groovy
-implementation 'com.github.Ragibn5:devicedetect:0.0.1'
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        mavenCentral()
+        maven { url 'https://jitpack.io' }
+    }
+}
+```
+
+Or, if you are managing the dependency repositories with build.gradle (older projects):
+Add `maven { url 'https://jitpack.io' }` at the end of `rootProject.allprojects.repositories` block:
+
+```groovy
+rootProject.allprojects {
+    repositories {
+        google()
+        mavenLocal()
+        mavenCentral()
+        maven { url = uri("https://jitpack.io") }
+    }
+}
+```
+
+Add this to your module build.gradle:
+
+```groovy
+implementation 'com.github.Ragibn5:devicedetect:0.0.3'
 ```
 
 ## Contributing

--- a/devicedetect/build.gradle.kts
+++ b/devicedetect/build.gradle.kts
@@ -58,7 +58,7 @@ publishing {
         create<MavenPublication>("release") {
             groupId = "com.ragibn5"
             artifactId = "devicedetect"
-            version = "0.0.1"
+            version = "0.0.3"
 
             afterEvaluate {
                 from(components["release"])

--- a/devicedetect/src/main/java/com/ragibn5/devicedetect/DeviceOS.kt
+++ b/devicedetect/src/main/java/com/ragibn5/devicedetect/DeviceOS.kt
@@ -1,4 +1,4 @@
-import com.ragibn5.devicedetect.DeviceManufacturer
+package com.ragibn5.devicedetect
 
 enum class DeviceOS(val manufacturer: DeviceManufacturer) {
     ////

--- a/devicedetect/src/main/java/com/ragibn5/devicedetect/DeviceVendor.kt
+++ b/devicedetect/src/main/java/com/ragibn5/devicedetect/DeviceVendor.kt
@@ -1,6 +1,5 @@
 package com.ragibn5.devicedetect
 
-import DeviceOS
 import android.os.Build
 import com.ragibn5.devicedetect.utils.DefaultPropertyReader
 import com.ragibn5.devicedetect.utils.DefaultTerminal
@@ -188,6 +187,7 @@ data class DeviceVendor(
             val vivoOSVersion = propertyReader.getProp("ro.vivo.os.version")?.lowercase()
 
             // Nothing
+            Build.BRAND
             // Example value: Nothing OS (3)
             val nothingOsVersion = propertyReader.getProp("ro.build.nothing.version")?.lowercase()
 


### PR DESCRIPTION
- Updated library version to 0.0.3 in `devicedetect/build.gradle.kts` and README.
- Added documentation for `DeviceOS` in README.
- Included a note in README about the current limited support for OS detection (Xiaomi and Transsion devices).
- Added instructions in README for adding JitPack repository for both `settings.gradle` and `build.gradle` dependency management.
- Created CHANGELOG entry for v0.0.3.
- Corrected package declaration in `DeviceOS.kt`.
- Removed unused import of `DeviceOS` from `DeviceVendor.kt`.