### PR TITLE
Main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to PiTrackerCommons will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.0.4, v0.0.5, v0.0.6] - 2025-09-18
+
+### Added
+
+- Support for new OS (BBK Group)
+    - ColorOS
+    - FunTouchOS
+    - RealmeUI
+    - OxygenOS
+
+### Changed
+
+- Revised device and OS detection logic.
+
+### Removed
+
+- OnePlusOS: Same as OxygenOS
+
 ## [v0.0.3] - 2025-08-19
 
 ### Added


### PR DESCRIPTION
- Added support for new OS versions from BBK Group: ColorOS, FunTouchOS, RealmeUI, and OxygenOS.
- Documented revised device and OS detection logic.
- Noted the removal of OnePlusOS as it is the same as OxygenOS.