### PR TITLE
Release/v0.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to PiTrackerCommons will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v1.0.0] - 2025-09-23
+## [v0.0.7] - 2025-09-23
 
 ### Changed
 
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated Gradle wrapper from version "8.10.2" to "8.13".
 - Renamed the `devicedetect` module to `device_detect`.
 - Updated the lib's publishing artifactId from "devicedetect" to "device-detect"".
-- Updated the lib's publishing version from "0.0.5" to "1.0.0".
+- Updated the lib's publishing version from "0.0.5" to "0.0.7".
 - Updated `jvmTarget` in the lib's `build.gradle.kts` to use `JavaVersion.VERSION_11.toString()`.
 - Updated module paths in `settings.gradle.kts`, `app/build.gradle.kts`, and `.idea/gradle.xml` to
   reflect the module rename.

--- a/device_detect/build.gradle.kts
+++ b/device_detect/build.gradle.kts
@@ -58,7 +58,7 @@ publishing {
         create<MavenPublication>("release") {
             groupId = "com.ragibn5"
             artifactId = "device-detect"
-            version = "1.0.0"
+            version = "0.0.7"
 
             afterEvaluate {
                 from(components["release"])


### PR DESCRIPTION
- Updated AGP from "8.8.2" to "8.13.0".
- Updated Kotlin from "1.9.24" to "1.9.25".
- Updated Gradle wrapper from version "8.10.2" to "8.13".
- Renamed the `devicedetect` module to `device_detect`.
- Updated the lib's publishing artifactId from "devicedetect" to "device-detect"".
- Updated the lib's publishing version from "0.0.5" to "0.0.7".
- Updated `jvmTarget` in the lib's `build.gradle.kts` to use `JavaVersion.VERSION_11.toString()`.
- Updated module paths in `settings.gradle.kts`, `app/build.gradle.kts`, and `.idea/gradle.xml` to reflect the module rename.