### PR TITLE
Release/v0.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to PiTrackerCommons will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v0.0.7] - 2025-09-23
+## [v0.0.8] - 2025-09-23
 
 ### Changed
 
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated Gradle wrapper from version "8.10.2" to "8.13".
 - Renamed the `devicedetect` module to `device_detect`.
 - Updated the lib's publishing artifactId from "devicedetect" to "device-detect"".
-- Updated the lib's publishing version from "0.0.5" to "0.0.7".
+- Updated the lib's publishing version from "0.0.5" to "0.0.8".
 - Updated `jvmTarget` in the lib's `build.gradle.kts` to use `JavaVersion.VERSION_11.toString()`.
 - Updated module paths in `settings.gradle.kts`, `app/build.gradle.kts`, and `.idea/gradle.xml` to
   reflect the module rename.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ rootProject.allprojects {
 Add this to your module build.gradle:
 
 ```groovy
-implementation 'com.github.Ragibn5:devicedetect:0.0.3'
+implementation 'com.github.Ragibn5:device-detect:v0.0.7'
 ```
 
 ## Contributing

--- a/device_detect/build.gradle.kts
+++ b/device_detect/build.gradle.kts
@@ -58,7 +58,7 @@ publishing {
         create<MavenPublication>("release") {
             groupId = "com.ragibn5"
             artifactId = "device-detect"
-            version = "0.0.7"
+            version = "0.0.8"
 
             afterEvaluate {
                 from(components["release"])


### PR DESCRIPTION
This commit updates CHANGELOG.md and the library version in `device_detect/build.gradle.kts` to `0.0.8`.
It also updates the README.md to reflect the new artifactId and version.