### PR TITLE
Refactor: Restrict visibility of internal components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to PiTrackerCommons will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.0.9] - 2025-09-23
+
+### Changed
+
+- Restricted visibility of components that are not required by users.
+
 ## [v0.0.8] - 2025-09-23
 
 ### Changed

--- a/app/src/main/java/com/ragibn5/devicedetectimpl/MainActivity.kt
+++ b/app/src/main/java/com/ragibn5/devicedetectimpl/MainActivity.kt
@@ -12,7 +12,6 @@ import androidx.core.content.FileProvider
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import com.ragibn5.devicedetect.DeviceVendor
-import com.ragibn5.devicedetect.utils.DefaultTerminal
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -36,7 +35,7 @@ class MainActivity : AppCompatActivity() {
         CoroutineScope(Dispatchers.IO).launch {
             val vendor = DeviceVendor.detect()
             val fingerprint = Build.FINGERPRINT
-            val commandResult = DefaultTerminal().executeCommand("getprop") ?: "N/A"
+            val commandResult = getPropCommandResult()
             CoroutineScope(Dispatchers.Main).launch {
                 findViewById<TextView>(R.id.overview).text = String.format(
                     "Brand: %s\nManufacturer: %s\nOS: %s\n\nFINGERPRINT: %s",
@@ -163,5 +162,13 @@ class MainActivity : AppCompatActivity() {
             .replace("!", "_")
             .replace("+", "_")
             .replace("=", "_");
+    }
+
+    fun getPropCommandResult(): String {
+        return Runtime.getRuntime()
+            .exec("getprop")
+            .inputStream
+            .bufferedReader()
+            .use { it.readText() }
     }
 }

--- a/device_detect/build.gradle.kts
+++ b/device_detect/build.gradle.kts
@@ -58,7 +58,7 @@ publishing {
         create<MavenPublication>("release") {
             groupId = "com.ragibn5"
             artifactId = "device-detect"
-            version = "0.0.8"
+            version = "0.0.9"
 
             afterEvaluate {
                 from(components["release"])

--- a/device_detect/src/main/java/com/ragibn5/devicedetect/utils/PropertyReader.kt
+++ b/device_detect/src/main/java/com/ragibn5/devicedetect/utils/PropertyReader.kt
@@ -3,7 +3,7 @@ package com.ragibn5.devicedetect.utils
 /**
  * Simple terminal interface.
  */
-fun interface PropertyReader {
+internal fun interface PropertyReader {
     /**
      * Get a system property.
      *
@@ -14,7 +14,7 @@ fun interface PropertyReader {
 }
 
 
-class DefaultPropertyReader(private val terminal: Terminal) : PropertyReader {
+internal class DefaultPropertyReader(private val terminal: Terminal) : PropertyReader {
     override fun getProp(propName: String): String? {
         return runCatching { terminal.executeCommand("getprop $propName") }.getOrElse {
             it.printStackTrace()

--- a/device_detect/src/main/java/com/ragibn5/devicedetect/utils/TerminalHelper.kt
+++ b/device_detect/src/main/java/com/ragibn5/devicedetect/utils/TerminalHelper.kt
@@ -5,7 +5,7 @@ import java.io.File
 /**
  * Simple terminal interface.
  */
-interface Terminal {
+internal interface Terminal {
     /**
      * Execute command.
      *
@@ -25,7 +25,7 @@ interface Terminal {
 /**
  * Default terminal implementation.
  * */
-class DefaultTerminal : Terminal {
+internal class DefaultTerminal : Terminal {
     override fun executeCommand(
         command: String,
         workingDir: File?,


### PR DESCRIPTION
This commit restricts the visibility of `Terminal`, `DefaultTerminal`, `PropertyReader`, and `DefaultPropertyReader` to internal. It also updates the library version to `0.0.9` in `device_detect/build.gradle.kts` and adds a corresponding entry to `CHANGELOG.md`. Additionally, the `MainActivity.kt` in the sample app is updated to use `Runtime.getRuntime().exec("getprop")` directly instead of relying on the now-internal `DefaultTerminal`.