### PR TITLE
Docs: Fix module path in README and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated Kotlin from "1.9.24" to "1.9.25".
 - Updated Gradle wrapper from version "8.10.2" to "8.13".
 - Renamed the `devicedetect` module to `device_detect`.
-- Updated the lib's publishing artifactId from "devicedetect" to "device-detect"".
+- Updated the lib's publishing artifactId from "devicedetect" to "device-detect".
 - Updated the lib's publishing version from "0.0.5" to "0.0.8".
 - Updated `jvmTarget` in the lib's `build.gradle.kts` to use `JavaVersion.VERSION_11.toString()`.
 - Updated module paths in `settings.gradle.kts`, `app/build.gradle.kts`, and `.idea/gradle.xml` to
@@ -47,18 +47,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [DeviceOS](devicedetect/src/main/java/com/ragibn5/devicedetect/DeviceOS.kt)
+- [DeviceOS](device_detect/src/main/java/com/ragibn5/devicedetect/DeviceOS.kt)
   An enum type representing the operating system of the device (limited support, see README).
 
 - ## [v0.0.1] - 2025-08-15
 
 ### Added
 
-- [DeviceVendor](devicedetect/src/main/java/com/ragibn5/devicedetect/DeviceVendor.kt)
+- [DeviceVendor](device_detect/src/main/java/com/ragibn5/devicedetect/DeviceVendor.kt)
   A value type containing the brand and manufacturer info.
-- [DeviceBrand](devicedetect/src/main/java/com/ragibn5/devicedetect/DeviceBrand.kt)
+- [DeviceBrand](device_detect/src/main/java/com/ragibn5/devicedetect/DeviceBrand.kt)
   An enum type representing the brand of the device.
-- [DeviceManufacturer](devicedetect/src/main/java/com/ragibn5/devicedetect/DeviceManufacturer.kt)
+- [DeviceManufacturer](device_detect/src/main/java/com/ragibn5/devicedetect/DeviceManufacturer.kt)
   An enum type representing the manufacturer of the device.
 
   Please see the [README](README.md) file for more details.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# devicedetect
+# device-detect
 
 A lightweight library for retrieving type-safe device and manufacturer-specific information on
 Android.
@@ -45,13 +45,13 @@ findViewById<TextView>(R.id.preview).setText(
 
 Available info (as of now):
 
-- [DeviceVendor](devicedetect/src/main/java/com/ragibn5/devicedetect/DeviceVendor.kt)
+- [DeviceVendor](device_detect/src/main/java/com/ragibn5/devicedetect/DeviceVendor.kt)
   A value type containing the brand and manufacturer info.
-- [DeviceBrand](devicedetect/src/main/java/com/ragibn5/devicedetect/DeviceBrand.kt)
+- [DeviceBrand](device_detect/src/main/java/com/ragibn5/devicedetect/DeviceBrand.kt)
   An enum type representing the brand of the device.
-- [DeviceManufacturer](devicedetect/src/main/java/com/ragibn5/devicedetect/DeviceManufacturer.kt)
+- [DeviceManufacturer](device_detect/src/main/java/com/ragibn5/devicedetect/DeviceManufacturer.kt)
   An enum type representing the manufacturer of the device.
-- [DeviceOS](devicedetect/src/main/java/com/ragibn5/devicedetect/DeviceOS.kt)
+- [DeviceOS](device_detect/src/main/java/com/ragibn5/devicedetect/DeviceOS.kt)
   An enum type representing the operating system of the device.
 
 Note, The OS detection is verified for only Xiaomi, Transsion, and Nothing devices as of now.
@@ -70,7 +70,7 @@ To build and publish a new release version of the library (to your local Maven r
 
 **Note:**
 Make sure you change the version inside the `publishing` block of the library's
-[`build.gradle`](devicedetect/build.gradle.kts) file before creating a new local release.
+[`build.gradle`](device_detect/build.gradle.kts) file before creating a new local release.
 Running the above command while not changing the version will overwrite the previous release build
 files.
 


### PR DESCRIPTION
This commit updates the module path from `devicedetect` to `device_detect` in README.md and CHANGELOG.md. It also corrects a typo in the artifactId in CHANGELOG.md.